### PR TITLE
[TESTS] Enable phpunit tests with configs in phpunit.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .sonar
 vendor
 composer.lock
+reports

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,18 @@
+<?php
+
+$vendorDirs = [
+    __DIR__ . '/vendor', // standalone package
+    __DIR__ . '/../..',  // embedded in another package
+];
+
+// locate the autoload
+$loader = null;
+
+foreach ($vendorDirs as $vendorDir) {
+    $file = "{$vendorDir}/autoload.php";
+
+    if (file_exists($file)) {
+        $loader = require_once($file);
+        break;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,7 @@
     ],
     "autoload": {
         "psr-4": {
-            "LearnosityQti\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
+            "LearnosityQti\\": "src/",
             "LearnosityQti\\Tests\\": "tests/"
         }
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,4 @@
-<phpunit bootstrap="vendor/autoload.php">
+<phpunit bootstrap="./bootstrap.php">
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
@@ -10,8 +10,9 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="coverage-clover" target="./tests/coverage.xml"/>
-        <log type="junit" target="./src/Tests/junit.xml" logIncompleteSkipped="false"/>
+        <log type="coverage-clover" target="./reports/coverage/coverage.xml"/>
+        <log type="junit" target="./reports/coverage/junit.xml" logIncompleteSkipped="false"/>
+        <log type="coverage-html" target="./reports/coverage/html" title="Learnosity" charset="UTF-8" yui="true" highlight="true" lowUpperBound="35" highLowerBound="70"/>
     </logging>
     <testsuites>
         <testsuite name="unit">


### PR DESCRIPTION
This PR enables phpunit tests with the following changes:
 - Add a bootstrap.php for tests, which detects whether the repository is a vendor or standalone package
 - Enables reporting in the directory reports (git-ignored)
 - remove autoload-dev (as this feature does not seem to do what was documented)