### PR TITLE
[BUG] Fix built-in response processing log message

### DIFF
--- a/src/Processors/QtiV2/In/Validation/BaseInteractionValidationBuilder.php
+++ b/src/Processors/QtiV2/In/Validation/BaseInteractionValidationBuilder.php
@@ -127,7 +127,7 @@ abstract class BaseInteractionValidationBuilder
                         return $this->getMatchCorrectTemplateValidation($responseProcessingScores);
                     }
 
-                    LogService::log('ResponseProcessing: Unrecognized scoring type: ' . print_r($results, true));
+                    LogService::log('ResponseProcessing: Built-in response processing used, but no response processing scores found');
                     break;
 
                 default:


### PR DESCRIPTION
This change replaces an erroneous log message in the `BaseInteractionValidationBuilder` class, which triggers the following PHP notice:

```
Undefined variable: results in learnosity-qti\src\Processors\QtiV2\In\Validation\BaseInteractionValidationBuilder.php on line 130:
LogService::log('ResponseProcessing: Unrecognized scoring type: ' . print_r($results, true));
```

This part of the code is executed in the case where built-in response processing is encountered, but no scores are able to be extracted by parsing the rules (either because the response processing is empty, or there are no parseable rules).

The message being logged was invalid as it referred to a non-existent `$results` variable, and incorrectly mentioned an issue with scoring type. This was a side-effect of an earlier change to the code which removed `$results` and changed the behavior of the conditional block above.

This is now fixed by replacing it with a message that better describes the issue.

Fixes #22.