### PR TITLE
[BUG] Preserve scoring_type and other item metadata

### DIFF
--- a/src/Services/ItemLayoutService.php
+++ b/src/Services/ItemLayoutService.php
@@ -146,7 +146,10 @@ class ItemLayoutService
             unset($item['content']);
         }
         if ($this->shouldRemoveItemMetadata) {
-            unset($item['metadata']);
+            unset($item['metadata']['authoring']);
+            if (empty($item['metadata'])) {
+                unset($item['metadata']);
+            }
         }
 
         return $item;


### PR DESCRIPTION
Fixes an issue, when migrating raw Learnosity Item JSON to the newer format, where in the process of stripping obsolete authoring metadata from the item, other important metadata fields (such as `scoring_type`) are also stripped. This change ensures that only `metadata.authoring` is stripped instead.