### PR TITLE
[BUG] convert:to:learnosity - Handle empty conversion results

### DIFF
--- a/src/Services/ConvertToLearnosityService.php
+++ b/src/Services/ConvertToLearnosityService.php
@@ -605,6 +605,10 @@ class ConvertToLearnosityService
      */
     private function updateJobManifest(array &$manifest, array $results)
     {
+        if (empty($results['qtiitems'])) {
+            return;
+        }
+
         foreach ($results['qtiitems'] as &$itemResult) {
             // Log ignored items
             if (!isset($itemResult['item'])) {

--- a/src/Services/ItemLayoutService.php
+++ b/src/Services/ItemLayoutService.php
@@ -71,6 +71,10 @@ class ItemLayoutService
      */
     protected function migrateBatchItems(array $batchItems)
     {
+        if (empty($batchItems['qtiitems'])) {
+            return $batchItems;
+        }
+
         $itemIndex = 0;
         $totalItemsCount = count($batchItems['qtiitems']);
         foreach ($batchItems['qtiitems'] as $fileKey => &$qtiItem) {


### PR DESCRIPTION
This commit fixes some fatal PHP errors in the convert:to:learnosity
command, in the case where it cannot find any valid items to convert,
that would cause the command to exit with an error and fail to
generate a manifest as expected and instead output the PHP errors.
Also, the command will not process any further packages after the
failed package.

The bug arises from assumptions around the `qtiitems` property of the
output never being empty. This assumption is false, and an empty list
of items is technically considered a valid scenario, if it results
from scanning a QTI package that does not contain any items files that
can be converted.

Now, the command does not fail if it encounters a package with no
convertable items, and instead outputs a JSON file with an empty
`qtiitems` list. Also, the command will continue to process any
further packages without issue.