### PR TITLE
Enable basic build/test integration support for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: php
+php:
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - '7.2'
+  - '7.3'
+
+env:
+  - COMPOSER_COMMAND=install
+  - COMPOSER_COMMAND=update
+
+install:
+  - composer ${COMPOSER_COMMAND}
+
+script: ./vendor/bin/phpunit
+


### PR DESCRIPTION
This change adds the basic necessary configurations for running builds
and PHPUnit tests in Travis CI, for several different versions of PHP.

The main purpose of this is to enable running automatic integration
tests on all supported PHP versions.