### PR TITLE
Store content package files in separate folders (WBL-62)

### DIFF
--- a/src/Processors/QtiV2/Out/Constants.php
+++ b/src/Processors/QtiV2/Out/Constants.php
@@ -42,8 +42,9 @@ class Constants
     const IMSQTI_METADATA_SCHEMA = array('LOMv1.0', 'QTIv2.1');
     const SCHEMA_NAME = 'QTIv2.1 Item Bank Package';
     const SCHEMA_VERSION = '2.1';
-    const VIDEO_FOLDER_NAME = 'video';
-    const AUDIO_FOLDER_NAME = 'audio';
-    const IMAGE_FOLDER_NAME = 'images';
-    const ITEMS_FOLDER_NAME = 'items';
+    const DIRNAME_VIDEO = 'video';
+    const DIRNAME_AUDIO = 'audio';
+    const DIRNAME_IMAGE = 'images';
+    const DIRNAME_ITEMS = 'items';
+    const DIRPATH_ASSET = '/vendor/learnosity/itembank/assets/';
 }

--- a/src/Services/ConvertToQtiService.php
+++ b/src/Services/ConvertToQtiService.php
@@ -104,20 +104,20 @@ class ConvertToQtiService
      */
     public function createAdditionalFolder($basePath)
     {
-        FileSystemHelper::createDirIfNotExists($basePath . '/' . LearnosityExportConstant::AUDIO_FOLDER_NAME);
-        FileSystemHelper::createDirIfNotExists($basePath . '/' . LearnosityExportConstant::VIDEO_FOLDER_NAME);
-        FileSystemHelper::createDirIfNotExists($basePath . '/' . LearnosityExportConstant::IMAGE_FOLDER_NAME);
-        FileSystemHelper::createDirIfNotExists($basePath . '/' . LearnosityExportConstant::ITEMS_FOLDER_NAME);
-        $this->moveAssestsFilesIntoRespectiveFolder($this->inputPath . '/' . 'assets', $basePath);
+        FileSystemHelper::createDirIfNotExists($basePath . '/' . LearnosityExportConstant::DIRNAME_AUDIO);
+        FileSystemHelper::createDirIfNotExists($basePath . '/' . LearnosityExportConstant::DIRNAME_VIDEO);
+        FileSystemHelper::createDirIfNotExists($basePath . '/' . LearnosityExportConstant::DIRNAME_IMAGES);
+        FileSystemHelper::createDirIfNotExists($basePath . '/' . LearnosityExportConstant::DIRNAME_ITEMS);
+        $this->copyAllAssetFiles($this->inputPath . '/' . 'assets', $basePath);
     }
 
     /**
-     * Move each files from assets folder to their respective folder
+     * Copy each files from assets folder to their respective folder
      *
      * @param type $sourcePath source path of the directory
      * @param type $destinationPath destination directory for copy files
      */
-    public function moveAssestsFilesIntoRespectiveFolder($sourcePath, $destinationPath)
+    public function copyAllAssetFiles($sourcePath, $destinationPath)
     {
         $dir = opendir($sourcePath);
         while (($file = readdir($dir)) !== false) {
@@ -557,25 +557,31 @@ class ConvertToQtiService
     {
         $files = array();
         foreach ($filesInfo as $info) {
-            $fileName = substr($info, strlen('/vendor/learnosity/itembank/assets/'));
-            $mimeType = MimeUtil::guessMimeType($fileName);
-            $mediaFormatArray = explode('/', $mimeType);
             $file = new File();
-            $href = '';
-            if (is_array($mediaFormatArray) && !empty($mediaFormatArray[0])) {
-                $mediaFormat = $mediaFormatArray[0];
-                if ($mediaFormat == 'video') {
-                    $href = LearnosityExportConstant::VIDEO_FOLDER_NAME . '/' . $fileName;
-                } elseif ($mediaFormat == 'audio') {
-                    $href = LearnosityExportConstant::AUDIO_FOLDER_NAME . '/' . $fileName;
-                } elseif ($mediaFormat == 'image') {
-                    $href = LearnosityExportConstant::IMAGE_FOLDER_NAME . '/' . $fileName;
-                }
-            }
+            $fileName = substr($info, strlen(LearnosityExportConstant::DIRPATH_ASSET));
+            $mimeType = MimeUtil::guessMimeType($fileName);
+            $href = $this->getAssetHref($fileName, $mimeType);
             $file->setHref($href);
             $files[] = $file;
         }
         return $files;
+    }
+    
+    private function getAssetHref($fileName, $mimeType)
+    {
+        $mediaFormatArray = explode('/', $mimeType);
+        $href = '';
+        if (is_array($mediaFormatArray) && !empty($mediaFormatArray[0])) {
+            $mediaFormat = $mediaFormatArray[0];
+            if ($mediaFormat == 'video') {
+                $href = LearnosityExportConstant::VIDEO_FOLDER_NAME . '/' . $fileName;
+            } elseif ($mediaFormat == 'audio') {
+                $href = LearnosityExportConstant::AUDIO_FOLDER_NAME . '/' . $fileName;
+            } elseif ($mediaFormat == 'image') {
+                $href = LearnosityExportConstant::IMAGE_FOLDER_NAME . '/' . $fileName;
+            }
+        }
+        return $href;
     }
 
     /**

--- a/src/Services/LearnosityToQtiPreProcessingService.php
+++ b/src/Services/LearnosityToQtiPreProcessingService.php
@@ -45,7 +45,7 @@ class LearnosityToQtiPreProcessingService
         }
 
         foreach ($html->find('img') as &$node) {
-            $src = $this->getSourceBasedOnMediaFormat($node->attr['src']);
+            $src = $this->getQtiMediaSrcFromLearnositySrc($node->attr['src']);
             $node->outertext = str_replace($node->attr['src'], $src, $node->outertext);
         }
 
@@ -110,20 +110,27 @@ class LearnosityToQtiPreProcessingService
         return null;
     }
 
-    private function getSourceBasedOnMediaFormat($src)
+    /**
+     * This method take the original media source and return the desired media path 
+     * for an item based on their media type.
+     *
+     * @param type $src source of the desired media
+     * @return string media href
+     */
+    private function getQtiMediaSrcFromLearnositySrc($src)
     {
-        $fileName = substr($src, strlen('/vendor/learnosity/itembank/assets/'));
+        $fileName = substr($src, strlen(LearnosityExportConstant::DIRPATH_ASSET));
         $mimeType = MimeUtil::guessMimeType($fileName);
         $mediaFormatArray = explode('/', $mimeType);
         $href = '';
         if (is_array($mediaFormatArray) && !empty($mediaFormatArray[0])) {
             $mediaFormat = $mediaFormatArray[0];
             if ($mediaFormat == 'video') {
-                $href = '../' . LearnosityExportConstant::VIDEO_FOLDER_NAME . '/' . $fileName;
+                $href = '../' . LearnosityExportConstant::DIRNAME_VIDEO . '/' . $fileName;
             } elseif ($mediaFormat == 'audio') {
-                $href = '../' . LearnosityExportConstant::AUDIO_FOLDER_NAME . '/' . $fileName;
+                $href = '../' . LearnosityExportConstant::DIRNAME_AUDIO . '/' . $fileName;
             } elseif ($mediaFormat == 'image') {
-                $href = '../' . LearnosityExportConstant::IMAGE_FOLDER_NAME . '/' . $fileName;
+                $href = '../' . LearnosityExportConstant::DIRNAME_IMAGE . '/' . $fileName;
             }
         }
         return $href;


### PR DESCRIPTION
The content package should look like this:

/content_package
  /audio
  /images
  /items
  /passages
  /video
  imsmanifest.xml
The audio folder should contain any mp3 or other audio files.

The images folder should contain any jpg, gif, png etc files.

The items folder contains all XML assessment item files.

The passages folder contains all HTML passages.

The video folder should contain any mp4 or other video files.

https://learnosity.atlassian.net/browse/WBL-62
