### PR TITLE
Support converting certain <rubricBlock> elements to distractor rationale (WBL-63)

### DIFF
--- a/src/Processors/QtiV2/In/DistractorRationaleResponseMapper.php
+++ b/src/Processors/QtiV2/In/DistractorRationaleResponseMapper.php
@@ -1,0 +1,68 @@
+<?php
+namespace LearnosityQti\Processors\QtiV2\In;
+
+
+use DOMElement;
+use LearnosityQti\Utils\QtiMarshallerUtil;
+use qtism\data\content\RubricBlock;
+use SplFileInfo;
+use LearnosityQti\Exceptions\MappingException;
+
+class DistractorRationaleResponseMapper
+{
+
+    public function __construct()
+    {
+        
+    }
+
+    public function parseWithDistractorRationaleResponseComponent(RubricBlock $rubricBlock)
+    {
+        $results = [];
+
+        // Fall back to using all the content in the <rubricBlock> verbatim as a single passage
+        $xml = QtiMarshallerUtil::marshall($rubricBlock);
+        if (strlen(trim($xml)) > 0) {
+            $dom = $this->getDomForXml($xml);
+            $innerContent = $this->getInnerXmlFragmentFromDom($dom);
+            $distractorRationale = array();
+            foreach ($innerContent->childNodes as $child) {
+                $distractorRationale[] = $child->ownerDocument->saveXML($child);
+            }
+
+            $results['distractor_rationale_response_level'] = $distractorRationale;
+        } else {
+            throw new MappingException('No content found; cannot create distractor rational response level');
+        }
+        return $results;
+    }
+    
+    private function getDomForXml($xml)
+    {
+        $dom = new \DOMDocument();
+
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput       = false;
+        $dom->substituteEntities = false;
+
+        $isValid = $dom->loadXML($xml);
+
+        if (!$isValid) {
+            throw new MappingException('Invalid XML; Failed to parse DOM for sharedpassage content');
+        }
+
+        return $dom;
+    }
+    
+    private function getInnerXmlFragmentFromDom(\DOMDocument $dom)
+    {
+        $fragment = $dom->createDocumentFragment();
+        $childNodes = $dom->documentElement->childNodes;
+        while (($node = $childNodes->item(0))) {
+            $node->parentNode->removeChild($node);
+            $fragment->appendChild($node);
+        }
+
+        return $fragment;
+    }
+}

--- a/src/Processors/QtiV2/In/DistractorRationaleResponseMapper.php
+++ b/src/Processors/QtiV2/In/DistractorRationaleResponseMapper.php
@@ -1,12 +1,10 @@
 <?php
 namespace LearnosityQti\Processors\QtiV2\In;
 
-
-use DOMElement;
+use DOMDocument;
+use LearnosityQti\Exceptions\MappingException;
 use LearnosityQti\Utils\QtiMarshallerUtil;
 use qtism\data\content\RubricBlock;
-use SplFileInfo;
-use LearnosityQti\Exceptions\MappingException;
 
 class DistractorRationaleResponseMapper
 {
@@ -39,7 +37,7 @@ class DistractorRationaleResponseMapper
     
     private function getDomForXml($xml)
     {
-        $dom = new \DOMDocument();
+        $dom = new DOMDocument();
 
         $dom->preserveWhiteSpace = false;
         $dom->formatOutput       = false;
@@ -54,7 +52,7 @@ class DistractorRationaleResponseMapper
         return $dom;
     }
     
-    private function getInnerXmlFragmentFromDom(\DOMDocument $dom)
+    private function getInnerXmlFragmentFromDom(DOMDocument $dom)
     {
         $fragment = $dom->createDocumentFragment();
         $childNodes = $dom->documentElement->childNodes;

--- a/src/Processors/QtiV2/In/DistractorRationaleResponseMapper.php
+++ b/src/Processors/QtiV2/In/DistractorRationaleResponseMapper.php
@@ -3,8 +3,10 @@ namespace LearnosityQti\Processors\QtiV2\In;
 
 use DOMDocument;
 use LearnosityQti\Exceptions\MappingException;
+use LearnosityQti\Utils\General\DOMHelper;
 use LearnosityQti\Utils\QtiMarshallerUtil;
 use qtism\data\content\RubricBlock;
+
 
 class DistractorRationaleResponseMapper
 {
@@ -21,8 +23,8 @@ class DistractorRationaleResponseMapper
         // Fall back to using all the content in the <rubricBlock> verbatim as a single passage
         $xml = QtiMarshallerUtil::marshall($rubricBlock);
         if (strlen(trim($xml)) > 0) {
-            $dom = $this->getDomForXml($xml);
-            $innerContent = $this->getInnerXmlFragmentFromDom($dom);
+            $dom = DOMHelper::getDomForXml($xml);
+            $innerContent = DOMHelper::getInnerXmlFragmentFromDom($dom);
             $distractorRationale = array();
             foreach ($innerContent->childNodes as $child) {
                 $distractorRationale[] = $child->ownerDocument->saveXML($child);
@@ -33,34 +35,5 @@ class DistractorRationaleResponseMapper
             throw new MappingException('No content found; cannot create distractor rational response level');
         }
         return $results;
-    }
-    
-    private function getDomForXml($xml)
-    {
-        $dom = new DOMDocument();
-
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput       = false;
-        $dom->substituteEntities = false;
-
-        $isValid = $dom->loadXML($xml);
-
-        if (!$isValid) {
-            throw new MappingException('Invalid XML; Failed to parse DOM for sharedpassage content');
-        }
-
-        return $dom;
-    }
-    
-    private function getInnerXmlFragmentFromDom(DOMDocument $dom)
-    {
-        $fragment = $dom->createDocumentFragment();
-        $childNodes = $dom->documentElement->childNodes;
-        while (($node = $childNodes->item(0))) {
-            $node->parentNode->removeChild($node);
-            $fragment->appendChild($node);
-        }
-
-        return $fragment;
     }
 }

--- a/src/Processors/QtiV2/In/ItemBuilders/AbstractItemBuilder.php
+++ b/src/Processors/QtiV2/In/ItemBuilders/AbstractItemBuilder.php
@@ -145,6 +145,9 @@ abstract class AbstractItemBuilder
                     });
                     $metadata->distractor_rationale_author = join('', array_column($value, 'content'));
                     break;
+                case 'distractor_rationale_response_level':
+                    $metadata->set_distractor_rationale_response_level($value);
+                    break;
 
                 case 'rubric_reference':
                     $metadata->set_rubric_reference($value);
@@ -242,10 +245,6 @@ abstract class AbstractItemBuilder
         if (!empty($result['question_metadata'])) {
             $this->setQuestionMetadata($result['question_metadata']);
         }
-        if(!empty($result['distractor_rationale_response_level'])) {
-            $this->setDistractorRationaleResponseLevel($result);
-        }
-
     }
 
     private function processScoringGuidanceContent(array $result)

--- a/src/Processors/QtiV2/In/ItemBuilders/AbstractItemBuilder.php
+++ b/src/Processors/QtiV2/In/ItemBuilders/AbstractItemBuilder.php
@@ -190,9 +190,9 @@ abstract class AbstractItemBuilder
         $this->metadata = array_merge_recursive($this->metadata, $itemMetadata);
     }
 
-    protected function setDistractorRationaleResponseLevel(array $distratorRationalResponseLevel)
+    protected function setDistractorRationaleResponseLevel(array $distractorRationaleResponseLevel)
     {
-        $this->metadata = array_merge_recursive($this->metadata, $distratorRationalResponseLevel);
+        $this->metadata = array_merge_recursive($this->metadata, $distractorRationaleResponseLevel);
     }
 
     public function setItemPointValue($itemPointValue)

--- a/src/Processors/QtiV2/In/ItemBuilders/AbstractItemBuilder.php
+++ b/src/Processors/QtiV2/In/ItemBuilders/AbstractItemBuilder.php
@@ -187,6 +187,11 @@ abstract class AbstractItemBuilder
         $this->metadata = array_merge_recursive($this->metadata, $itemMetadata);
     }
 
+    protected function setDistractorRationaleResponseLevel(array $distratorRationalResponseLevel)
+    {
+        $this->metadata = array_merge_recursive($this->metadata, $distratorRationalResponseLevel);
+    }
+
     public function setItemPointValue($itemPointValue)
     {
         $this->itemPointValue = $itemPointValue;
@@ -237,6 +242,10 @@ abstract class AbstractItemBuilder
         if (!empty($result['question_metadata'])) {
             $this->setQuestionMetadata($result['question_metadata']);
         }
+        if(!empty($result['distractor_rationale_response_level'])) {
+            $this->setDistractorRationaleResponseLevel($result);
+        }
+
     }
 
     private function processScoringGuidanceContent(array $result)

--- a/src/Processors/QtiV2/In/RubricBlockMapper.php
+++ b/src/Processors/QtiV2/In/RubricBlockMapper.php
@@ -2,15 +2,24 @@
 
 namespace LearnosityQti\Processors\QtiV2\In;
 
+use DOMDocument;
+use DOMElement;
+use DOMXPath;
+use LearnosityQti\Entities\Question;
+use LearnosityQti\Entities\QuestionTypes\rating;
+use LearnosityQti\Exceptions\MappingException;
+use LearnosityQti\Processors\QtiV2\In\DistractorRationaleResponseMapper;
+use LearnosityQti\Processors\QtiV2\In\SharedPassageMapper;
+use LearnosityQti\Services\LogService;
+use LearnosityQti\Utils\DOMHelper;
+use LearnosityQti\Utils\QtiMarshallerUtil;
+use LearnosityQti\Utils\UuidUtil;
+use LearnosityQti\Utils\Xml\EntityUtil as XmlEntityUtil;
 use qtism\data\content\RubricBlock;
 use qtism\data\storage\xml\XmlDocument;
 use qtism\data\View;
-use LearnosityQti\Exceptions\MappingException;
-use LearnosityQti\Processors\QtiV2\In\SharedPassageMapper;
-use LearnosityQti\Processors\QtiV2\In\DistractorRationaleResponseMapper;
-use LearnosityQti\Utils\QtiMarshallerUtil;
-use LearnosityQti\Utils\Xml\EntityUtil as XmlEntityUtil;
-use LearnosityQti\Services\LogService;
+use qtism\data\ViewCollection;
+use function ctype_digit;
 
 class RubricBlockMapper
 {
@@ -72,20 +81,7 @@ class RubricBlockMapper
                     $mapper = new DistractorRationaleResponseMapper();
                     $distractorRationalResponseLevelArray = $mapper->parseWithDistractorRationaleResponseComponent($rubricBlock);
                     $result ['question_metadata'] = $distractorRationalResponseLevelArray;
-                }
-                break;
-
-            case ($rubricBlock->getUse() === 'stimulus'):
-                if ($views->contains(View::CANDIDATE)) {
-                    $contents = QtiMarshallerUtil::marshallCollection($rubricBlock->getContent());
-                    $result = [
-                        'stimulus' => $contents,
-                    ];
-                }
-                break;
-
-            case ($rubricBlock->getClass() === 'DistractorRationale'):
-                if ($views->contains(View::AUTHOR)) {
+                } else if ($views->contains(View::AUTHOR)) {
                     $result = [
                         'question_metadata' => [
                             'distractor_rationale_author' => [
@@ -95,6 +91,15 @@ class RubricBlockMapper
                                 ]
                             ],
                         ],
+                    ];
+                }
+                break;
+
+            case ($rubricBlock->getUse() === 'stimulus'):
+                if ($views->contains(View::CANDIDATE)) {
+                    $contents = QtiMarshallerUtil::marshallCollection($rubricBlock->getContent());
+                    $result = [
+                        'stimulus' => $contents,
                     ];
                 }
                 break;
@@ -128,7 +133,7 @@ class RubricBlockMapper
      * @param  boolean $validateXml - whether to validate the XML
      *                              before attempting to deserialize it
      *
-     * @return \qtism\data\storage\xml\XmlDocument
+     * @return XmlDocument
      */
     protected function deserializeXml($xmlString, $validateXml)
     {
@@ -141,20 +146,7 @@ class RubricBlockMapper
         return $xmlDocument;
     }
 
-    private function getDomForXml($xml)
-    {
-        $dom = new \DOMDocument();
-
-        $dom->preserveWhiteSpace = false;
-        $dom->formatOutput       = false;
-        $dom->substituteEntities = false;
-
-        $dom->loadXML($xml);
-
-        return $dom;
-    }
-
-    private function getInnerXmlFragmentFromDom(\DOMDocument $dom)
+    private function getInnerXmlFragmentFromDom(DOMDocument $dom)
     {
         $fragment = $dom->createDocumentFragment();
         $childNodes = $dom->documentElement->childNodes;
@@ -171,11 +163,11 @@ class RubricBlockMapper
      *
      * The rubric block must be the root element of the document.
      *
-     * @param  \qtism\data\storage\xml\XmlDocument $xmlDocument
+     * @param  XmlDocument $xmlDocument
      *
-     * @return \qtism\data\content\RubricBlock
+     * @return RubricBlock
      *
-     * @throws \LearnosityQti\Exceptions\MappingException
+     * @throws MappingException
      */
     private function getRubricBlockFromXmlDocument(XmlDocument $xmlDocument)
     {
@@ -187,7 +179,7 @@ class RubricBlockMapper
         return $rubricBlock;
     }
 
-    private function parseRubricTableContentFromXmlUsingXPath(\DOMXPath $xpath)
+    private function parseRubricTableContentFromXmlUsingXPath(DOMXPath $xpath)
     {
         $aliasColumns = [
             'score' => 'value',
@@ -253,9 +245,9 @@ class RubricBlockMapper
             $xml = QtiMarshallerUtil::marshall($rubricBlock);
 
             // Prevent/handle XML parse errors (from bad XML input)
-            $xml = $this->sanitizeXml($xml);
-            $dom = $this->getDomForXml($xml);
-            $xpath = new \DOMXPath($dom);
+            $xml = DOMHelper::sanitizeXml($xml);
+            $dom = DOMHelper::getDomForXml($xml);
+            $xpath = new DOMXPath($dom);
 
             // Prepare inner rubric content
             $innerContentNode = $this->getInnerXmlFragmentFromDom($dom);
@@ -356,26 +348,11 @@ class RubricBlockMapper
 
         // Create a rating question type
         // FIXME: Need to deal with random reference problem here too (see shared passages)
-        $rating = new \LearnosityQti\Entities\QuestionTypes\rating('rating', $ratingOptions);
+        $rating = new rating('rating', $ratingOptions);
         $rating->set_stimulus($innerHTML);
-        $ratingQuestion = new \LearnosityQti\Entities\Question('rating', \LearnosityQti\Utils\UuidUtil::generate(), $rating);
+        $ratingQuestion = new Question('rating', UuidUtil::generate(), $rating);
 
         return $ratingQuestion;
-    }
-
-    private function sanitizeXml($xml)
-    {
-        $dom = new \DOMDocument('1.0', 'UTF-8');
-        libxml_use_internal_errors(true);
-
-        // HACK: Pass the version and encoding to prevent libxml from decoding HTML entities (esp. &amp; which libxml borks at)
-        $dom->loadHTML('<?xml version="1.0" encoding="UTF-8">'.$xml, LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED);
-        $xml = $dom->saveXML($dom->documentElement);
-
-        // HACK: Handle the fact that XML can't handle named entities (and HTML5 has no DTD for it)
-        $xml = XmlEntityUtil::convertNamedEntitiesToHexInString($xml);
-
-        return $xml;
     }
 
     private function useRubricPointValueForRubric(RubricBlock $rubricBlock)

--- a/src/Processors/QtiV2/In/RubricBlockMapper.php
+++ b/src/Processors/QtiV2/In/RubricBlockMapper.php
@@ -67,6 +67,7 @@ class RubricBlockMapper
         /** @var ViewCollection $views */
         $views = $rubricBlock->getViews();
         // Get the correct mapper for the <rubricBlock>
+        print_r($rubricBlock);
         switch (true) {
             case ($rubricBlock->getUse() === 'context'):
                 if ($views->contains(View::CANDIDATE)) {
@@ -76,6 +77,25 @@ class RubricBlockMapper
                 break;
 
             case ($rubricBlock->getUse() === 'rationale'):
+                if ($views->contains(View::CANDIDATE)) {
+                    $mapper = new DistractorRationaleResponseMapper();
+                    $distractorRationalResponseLevelArray = $mapper->parseWithDistractorRationaleResponseComponent($rubricBlock);
+                    $result ['question_metadata'] = $distractorRationalResponseLevelArray;
+                } else if ($views->contains(View::AUTHOR)) {
+                    $result = [
+                        'question_metadata' => [
+                            'distractor_rationale_author' => [
+                                [
+                                    'label' => $rubricBlock->getLabel(),
+                                    'content' => QtiMarshallerUtil::marshallCollection($rubricBlock->getContent()),
+                                ]
+                            ],
+                        ],
+                    ];
+                }
+                break;
+
+            case ($rubricBlock->getClass() === 'DistractorRationale'):
                 if ($views->contains(View::CANDIDATE)) {
                     $mapper = new DistractorRationaleResponseMapper();
                     $distractorRationalResponseLevelArray = $mapper->parseWithDistractorRationaleResponseComponent($rubricBlock);

--- a/src/Processors/QtiV2/In/RubricBlockMapper.php
+++ b/src/Processors/QtiV2/In/RubricBlockMapper.php
@@ -70,7 +70,8 @@ class RubricBlockMapper
             case ($rubricBlock->getUse() === 'rationale'):
                 if ($views->contains(View::CANDIDATE)) {
                     $mapper = new DistractorRationaleResponseMapper();
-                    $result = $mapper->parseWithDistractorRationaleResponseComponent($rubricBlock);
+                    $distractorRationalResponseLevelArray = $mapper->parseWithDistractorRationaleResponseComponent($rubricBlock);
+                    $result ['question_metadata'] = $distractorRationalResponseLevelArray;
                 }
                 break;
 

--- a/src/Processors/QtiV2/In/RubricBlockMapper.php
+++ b/src/Processors/QtiV2/In/RubricBlockMapper.php
@@ -67,7 +67,6 @@ class RubricBlockMapper
         /** @var ViewCollection $views */
         $views = $rubricBlock->getViews();
         // Get the correct mapper for the <rubricBlock>
-        print_r($rubricBlock);
         switch (true) {
             case ($rubricBlock->getUse() === 'context'):
                 if ($views->contains(View::CANDIDATE)) {
@@ -76,26 +75,9 @@ class RubricBlockMapper
                 }
                 break;
 
-            case ($rubricBlock->getUse() === 'rationale'):
-                if ($views->contains(View::CANDIDATE)) {
-                    $mapper = new DistractorRationaleResponseMapper();
-                    $distractorRationalResponseLevelArray = $mapper->parseWithDistractorRationaleResponseComponent($rubricBlock);
-                    $result ['question_metadata'] = $distractorRationalResponseLevelArray;
-                } else if ($views->contains(View::AUTHOR)) {
-                    $result = [
-                        'question_metadata' => [
-                            'distractor_rationale_author' => [
-                                [
-                                    'label' => $rubricBlock->getLabel(),
-                                    'content' => QtiMarshallerUtil::marshallCollection($rubricBlock->getContent()),
-                                ]
-                            ],
-                        ],
-                    ];
-                }
-                break;
-
             case ($rubricBlock->getClass() === 'DistractorRationale'):
+                /* falls through */
+            case ($rubricBlock->getUse() === 'rationale'):
                 if ($views->contains(View::CANDIDATE)) {
                     $mapper = new DistractorRationaleResponseMapper();
                     $distractorRationalResponseLevelArray = $mapper->parseWithDistractorRationaleResponseComponent($rubricBlock);

--- a/src/Processors/QtiV2/In/RubricBlockMapper.php
+++ b/src/Processors/QtiV2/In/RubricBlockMapper.php
@@ -11,10 +11,9 @@ use LearnosityQti\Exceptions\MappingException;
 use LearnosityQti\Processors\QtiV2\In\DistractorRationaleResponseMapper;
 use LearnosityQti\Processors\QtiV2\In\SharedPassageMapper;
 use LearnosityQti\Services\LogService;
-use LearnosityQti\Utils\DOMHelper;
+use LearnosityQti\Utils\General\DOMHelper;
 use LearnosityQti\Utils\QtiMarshallerUtil;
 use LearnosityQti\Utils\UuidUtil;
-use LearnosityQti\Utils\Xml\EntityUtil as XmlEntityUtil;
 use qtism\data\content\RubricBlock;
 use qtism\data\storage\xml\XmlDocument;
 use qtism\data\View;
@@ -146,18 +145,6 @@ class RubricBlockMapper
         return $xmlDocument;
     }
 
-    private function getInnerXmlFragmentFromDom(DOMDocument $dom)
-    {
-        $fragment = $dom->createDocumentFragment();
-        $childNodes = $dom->documentElement->childNodes;
-        while (($node = $childNodes->item(0))) {
-            $node->parentNode->removeChild($node);
-            $fragment->appendChild($node);
-        }
-
-        return $fragment;
-    }
-
     /**
      * Retrieves the rubric block from a given XML document.
      *
@@ -250,7 +237,7 @@ class RubricBlockMapper
             $xpath = new DOMXPath($dom);
 
             // Prepare inner rubric content
-            $innerContentNode = $this->getInnerXmlFragmentFromDom($dom);
+            $innerContentNode = DOMHelper::getInnerXmlFragmentFromDom($dom);
             // XXX: The following needs to be done in this order. Need to figure out why
             $innerHTML = $dom->saveXML($innerContentNode);
             $dom->replaceChild($innerContentNode, $dom->documentElement);

--- a/src/Processors/QtiV2/In/RubricBlockMapper.php
+++ b/src/Processors/QtiV2/In/RubricBlockMapper.php
@@ -7,6 +7,7 @@ use qtism\data\storage\xml\XmlDocument;
 use qtism\data\View;
 use LearnosityQti\Exceptions\MappingException;
 use LearnosityQti\Processors\QtiV2\In\SharedPassageMapper;
+use LearnosityQti\Processors\QtiV2\In\DistractorRationaleResponseMapper;
 use LearnosityQti\Utils\QtiMarshallerUtil;
 use LearnosityQti\Utils\Xml\EntityUtil as XmlEntityUtil;
 use LearnosityQti\Services\LogService;
@@ -63,6 +64,13 @@ class RubricBlockMapper
                 if ($views->contains(View::CANDIDATE)) {
                     $mapper = new SharedPassageMapper($this->sourceDirectoryPath);
                     $result = $mapper->parseWithRubricBlockComponent($rubricBlock);
+                }
+                break;
+
+            case ($rubricBlock->getUse() === 'rationale'):
+                if ($views->contains(View::CANDIDATE)) {
+                    $mapper = new DistractorRationaleResponseMapper();
+                    $result = $mapper->parseWithDistractorRationaleResponseComponent($rubricBlock);
                 }
                 break;
 

--- a/src/Processors/QtiV2/In/SharedPassageMapper.php
+++ b/src/Processors/QtiV2/In/SharedPassageMapper.php
@@ -1,5 +1,5 @@
 <?php
-include "../../../Utils/General/DOMHelper.php";
+
 namespace LearnosityQti\Processors\QtiV2\In;
 
 use DOMDocument;
@@ -11,7 +11,7 @@ use LearnosityQti\Entities\Question;
 use LearnosityQti\Entities\QuestionTypes\sharedpassage;
 use LearnosityQti\Exceptions\MappingException;
 use LearnosityQti\Services\LogService;
-use LearnosityQti\Utils\DOMHelper;
+use LearnosityQti\Utils\General\DOMHelper;
 use LearnosityQti\Utils\QtiMarshallerUtil;
 use LearnosityQti\Utils\UuidUtil;
 use qtism\data\content\RubricBlock;
@@ -114,7 +114,7 @@ class SharedPassageMapper
             $xml = QtiMarshallerUtil::marshall($rubricBlock);
             if (strlen(trim($xml)) > 0) {
                 $dom          = DOMHelper::getDomForXml($xml);
-                $innerContent = $this->getInnerXmlFragmentFromDom($dom);
+                $innerContent = DOMHelper::getInnerXmlFragmentFromDom($dom);
                 $results      = $this->parseXml($dom->saveXML($innerContent));
             } elseif ($this->isEmptyAllowed()) {
                 $results      = $this->parseXml($xml);
@@ -221,33 +221,6 @@ class SharedPassageMapper
         $htmlDom->replaceChild($xmlDom, $htmlDom->documentElement);
 
         return $htmlDom;
-    }
-
-    private function getInnerXmlFragmentFromDom(\DOMDocument $dom)
-    {
-        $fragment = $dom->createDocumentFragment();
-        $childNodes = $dom->documentElement->childNodes;
-        while (($node = $childNodes->item(0))) {
-            $node->parentNode->removeChild($node);
-            $fragment->appendChild($node);
-        }
-
-        return $fragment;
-    }
-
-    private function getFragmentWrapperDocumentElementForDom(\DOMDocument $dom)
-    {
-        /** @var DOMDocument $dom */
-        $fragmentWrapper = $dom->createDocumentFragment();
-
-        while ($dom->childNodes->length > 0) {
-            /** @var DOMNode $childNode */
-            $fragmentWrapper->appendChild($dom->childNodes->item(0));
-        }
-
-        $dom->replaceChild($fragmentWrapper, $dom);
-
-        return $fragmentWrapper;
     }
 
     private function parsePassageContentFromDom(DOMDocument $htmlDom)

--- a/src/Utils/General/DOMHelper.php
+++ b/src/Utils/General/DOMHelper.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace LearnosityQti\Utils;
+
+use LearnosityQti\Exceptions\MappingException;
+
+class DOMHelper
+{
+
+    public static function getDomForXml($xml)
+    {
+        $dom = new \DOMDocument();
+
+        $dom->preserveWhiteSpace = false;
+        $dom->formatOutput = false;
+        $dom->substituteEntities = false;
+
+        $isValid = $dom->loadXML($xml);
+
+        if (!$isValid) {
+            throw new MappingException('Invalid XML; Failed to parse DOM for sharedpassage content');
+        }
+
+        return $dom;
+    }
+    
+    public static function sanitizeXml($xml)
+    {
+        $xml = trim($xml);
+
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $previousLibXmlSetting = libxml_use_internal_errors(true);
+
+        // HACK: Pass the version and encoding to prevent libxml from decoding HTML entities (esp. &amp; which libxml borks at)
+        // Only do this if it hasnt already been passed along in the xml string. Sometimes, we read from a file, and sometimes
+        // we read from a block inside another file.
+        if (strpos($xml, '<?xml ') !== false) {
+            $xml = substr($xml, strpos($xml, '>') + 1);
+        }
+        $xml = '<?xml version="1.0" encoding="UTF-8">' . "<div>$xml</div>";
+
+        $dom->loadHTML($xml, LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED);
+        $xml = $dom->saveXML($this->getFragmentWrapperDocumentElementForDom($dom));
+
+        // HACK: Handle the fact that XML can't handle named entities (and HTML5 has no DTD for it)
+        $xml = XmlEntityUtil::convertNamedEntitiesToHexInString($xml);
+
+        libxml_clear_errors();
+        libxml_use_internal_errors($previousLibXmlSetting);
+
+        return $xml;
+    }
+}

--- a/src/Utils/General/DOMHelper.php
+++ b/src/Utils/General/DOMHelper.php
@@ -64,7 +64,7 @@ class DOMHelper
         return $fragment;
     }
 
-    private function getFragmentWrapperDocumentElementForDom(\DOMDocument $dom)
+    private static function getFragmentWrapperDocumentElementForDom(\DOMDocument $dom)
     {
         /** @var DOMDocument $dom */
         $fragmentWrapper = $dom->createDocumentFragment();

--- a/src/Utils/General/DOMHelper.php
+++ b/src/Utils/General/DOMHelper.php
@@ -41,7 +41,7 @@ class DOMHelper
         $xml = '<?xml version="1.0" encoding="UTF-8">' . "<div>$xml</div>";
 
         $dom->loadHTML($xml, LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED);
-        $xml = $dom->saveXML($this->getFragmentWrapperDocumentElementForDom($dom));
+        $xml = $dom->saveXML(static::getFragmentWrapperDocumentElementForDom($dom));
 
         // HACK: Handle the fact that XML can't handle named entities (and HTML5 has no DTD for it)
         $xml = XmlEntityUtil::convertNamedEntitiesToHexInString($xml);

--- a/src/Utils/General/DOMHelper.php
+++ b/src/Utils/General/DOMHelper.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace LearnosityQti\Utils;
+namespace LearnosityQti\Utils\General;
 
 use LearnosityQti\Exceptions\MappingException;
+use LearnosityQti\Utils\Xml\EntityUtil as XmlEntityUtil;
 
 class DOMHelper
 {
@@ -49,5 +50,32 @@ class DOMHelper
         libxml_use_internal_errors($previousLibXmlSetting);
 
         return $xml;
+    }
+
+    public static function getInnerXmlFragmentFromDom(\DOMDocument $dom)
+    {
+        $fragment = $dom->createDocumentFragment();
+        $childNodes = $dom->documentElement->childNodes;
+        while (($node = $childNodes->item(0))) {
+            $node->parentNode->removeChild($node);
+            $fragment->appendChild($node);
+        }
+
+        return $fragment;
+    }
+
+    private function getFragmentWrapperDocumentElementForDom(\DOMDocument $dom)
+    {
+        /** @var DOMDocument $dom */
+        $fragmentWrapper = $dom->createDocumentFragment();
+
+        while ($dom->childNodes->length > 0) {
+            /** @var DOMNode $childNode */
+            $fragmentWrapper->appendChild($dom->childNodes->item(0));
+        }
+
+        $dom->replaceChild($fragmentWrapper, $dom);
+
+        return $fragmentWrapper;
     }
 }


### PR DESCRIPTION
Some QTI assessment items will have content in <rubricBlock> elements. Some of those we map to shared passages, but some should be mapped to Learnosity metadata.distractor_rationale_response_level for students to see.

For more details Please see the following JIRA Ticket -
https://learnosity.atlassian.net/browse/WBL-63