### PR TITLE
<graphicGapMatchInteraction> should be converted to imageclozeassociationV2 (WBL-64)

### DIFF
--- a/src/Processors/QtiV2/In/Interactions/GraphicGapMatchInteractionMapper.php
+++ b/src/Processors/QtiV2/In/Interactions/GraphicGapMatchInteractionMapper.php
@@ -48,7 +48,7 @@ class GraphicGapMatchInteractionMapper extends AbstractInteractionMapper
         }
 
         $question = new imageclozeassociation(
-            'imageclozeassociation',
+            'imageclozeassociationV2',
             $image,
             $responsePosition,
             array_values($possibleResponseMapping)


### PR DESCRIPTION
Any <graphicGapMatchInteraction> interactions should be converted to imageclozeassociationV2.

 Right now they are being converted to imageclozeassociation (note the lack of "V2"). This is the legacy type which we don't want to use.