### PR TITLE
Converted audio doesn't contain full path to asset not full set of attributes (WBL-65)

### DIFF
--- a/src/Processors/QtiV2/In/Constants.php
+++ b/src/Processors/QtiV2/In/Constants.php
@@ -27,4 +27,5 @@ class Constants
     ];
     
     public static $baseLearnosityAssetsUrl = 'https://assets.learnosity.com/organisations/';
+    public static $baseLearnosityAudioUrl = 'https://assets.staging.learnosity.com/organisations/';
 }

--- a/src/Processors/QtiV2/Marshallers/LearnosityObjectMarshaller.php
+++ b/src/Processors/QtiV2/Marshallers/LearnosityObjectMarshaller.php
@@ -3,8 +3,11 @@
 namespace LearnosityQti\Processors\QtiV2\Marshallers;
 
 use LearnosityQti\Processors\QtiV2\Out\ContentCollectionBuilder;
+use LearnosityQti\Services\ConvertToLearnosityService;
 use LearnosityQti\Services\LogService;
 use LearnosityQti\Utils\QtiMarshallerUtil;
+use LearnosityQti\Utils\UuidUtil;
+use LearnosityQti\Processors\QtiV2\In\Constants;
 use qtism\data\content\xhtml\ObjectElement;
 use qtism\data\QtiComponent;
 use qtism\data\storage\xml\marshalling\ObjectMarshaller;
@@ -19,6 +22,7 @@ class LearnosityObjectMarshaller extends ObjectMarshaller
 
     protected function marshallChildrenKnown(QtiComponent $component, array $elements)
     {
+        $learnosityServiceObject = ConvertToLearnosityService::getInstance();
         /** @var ObjectElement $component */
         switch ($this->getMIMEType($component->getType())) {
             case self::MIME_IMAGE:
@@ -31,8 +35,10 @@ class LearnosityObjectMarshaller extends ObjectMarshaller
                 $this->checkObjectComponents($component, '`audioplayer` feature');
                 $element = self::getDOMCradle()->createElement('span');
                 $element->setAttribute('class', 'learnosity-feature');
+                $element->setAttribute('data-player', 'button');
+                $element->setAttribute("data-simplefeature_id", UuidUtil::generate());
                 $element->setAttribute('data-type', 'audioplayer');
-                $element->setAttribute('data-src', $component->getData());
+                $element->setAttribute('data-src', $this->getAudioUrl($component->getData()));
                 return $element;
                 break;
             case self::MIME_VIDEO:
@@ -80,5 +86,14 @@ class LearnosityObjectMarshaller extends ObjectMarshaller
             return self::MIME_HTML;
         }
         return self::MIME_NOT_SUPPORTED;
+    }
+
+    private function getAudioUrl($audioPath)
+    {
+        $learnosityServiceObject = ConvertToLearnosityService::getInstance();
+        $organisationId = $learnosityServiceObject->getOrganisationId();
+        $audioArray = explode('/', $audioPath);
+        $audioBaseUrl = Constants::$baseLearnosityAudioUrl . $organisationId . "/" . end($audioArray);
+        return $audioBaseUrl;
     }
 }

--- a/src/Services/ConvertToLearnosityService.php
+++ b/src/Services/ConvertToLearnosityService.php
@@ -82,6 +82,11 @@ class ConvertToLearnosityService
         return $this->inputPath;
     }
 
+    public function getOrganisationId()
+    {
+        return $this->organisationId;
+    }
+
     public function isUsingMetadataIdentifier()
     {
         return $this->useMetadataIdentifier;


### PR DESCRIPTION
When converting QTI to Learnosity, audio files (once converted) don't contain the full path in the same way that images do. Also, the <span> is missing 2 necessary data attributes and should be fully closed.
Desired JSON output
 ```
<span>
    class="learnosity-feature" 
    data-player="button" 
    data-simplefeature_id="a791ce66-22be-4537-b0b8-2a3d80b58917" 
    data-src="https://assets.staging.learnosity.com/organisations/1/2.mp3" 
    data-type="audioplayer">
</span>
```
https://learnosity.atlassian.net/browse/WBL-65