### PR TITLE
Generate passage-only items from the manifest (WBL-66)

### DIFF
--- a/src/Services/ConvertToLearnosityService.php
+++ b/src/Services/ConvertToLearnosityService.php
@@ -397,7 +397,7 @@ class ConvertToLearnosityService
 
             $resourcePath = $currentDir . '/' . $resourceHref;
             $results = $this->convertAssessmentItem($xmlString, $itemReference, $resourcePath, $metadata, $itemTagsArray, $resourceType);
-            } catch (\Exception $e) {
+        } catch (\Exception $e) {
             $targetFilename = $resourceHref;
             $message = $e->getMessage();
             $results = ['exception' => $targetFilename . '-' . $message];


### PR DESCRIPTION
This is for converting QTI to Learnosity.

We want to generate items with passages only, from the manifest. There will be a <resource> element that links to a separate HTML file (the passage) in the content package.
Metadata
As these are still Learnosity “items”, the LOM should be processed for tags as they are with regular XML items to convert.

Command flag
Can we have this functionality be opt-in? So, if a flag is passed to the command in the terminal, the library will also convert passages to items. Something like --passage-only-items

Expected output (JSON)
 

```
{
    "item": {
        "reference": "LEAR-VG-b107bfee-a18e-4753-ab9a-f2c18ce058a9",
        "content": "<div class=\"row\"><div class=\"col-xs-12\"><span class=\"learnosity-feature feature-50acf8bd-61fd-411a-aeae-85c3550aee22\"></span></div></div>",
        "status": "published",
        "definition": {
            "widgets": [
                {
                    "reference": "50acf8bd-61fd-411a-aeae-85c3550aee22"
                }
            ],
            "template": "dynamic"
        },
        "tags": []
    },
    "questions": [],
    "features": [
        {
            "type": "sharedpassage",
            "widget_type": "feature",
            "reference": "50acf8bd-61fd-411a-aeae-85c3550aee22",
            "data": {
                "type": "sharedpassage",
                "content": "<p>aScelerisque vestibulum</p>"
            },
            "metadata": {
                "name": "Passage",
                "template_reference": "d5d43bd6-d02a-4969-a79a-e10b344549a8"
            }
        }
    ]
}
```