### PR TITLE
Items fail to convert (WBL-67)

### DIFF
--- a/src/Services/ConvertToQtiService.php
+++ b/src/Services/ConvertToQtiService.php
@@ -199,7 +199,6 @@ class ConvertToQtiService
         $content = $json['content'];
         $tags = $json['tags'];
         $itemReference = $json['reference'];
-
         foreach ($json['questions'] as $question) :
             $question['content'] = $content;
             $question['itemreference'] = $itemReference;

--- a/src/Services/ConvertToQtiService.php
+++ b/src/Services/ConvertToQtiService.php
@@ -185,7 +185,7 @@ class ConvertToQtiService
     /**
      * Converts Learnosity JSON to QTI
      *
-     * @param  string $jsonString
+     * @param  string $json
      *
      * @return array - the results of the conversion
      *

--- a/src/Services/ConvertToQtiService.php
+++ b/src/Services/ConvertToQtiService.php
@@ -145,7 +145,12 @@ class ConvertToQtiService
     private function convertLearnosityInDirectory($file)
     {
         $this->output->writeln("<comment>Converting Learnosity JSON {$file}</comment>");
-        return $this->convertAssessmentItem(json_decode(file_get_contents($file), true));
+        $itemContent = $this->checkAndAddNamespaceInMathTag(file_get_contents($file));
+        return $this->convertAssessmentItem(json_decode($itemContent, true));
+    }
+
+    private function checkAndAddNamespaceInMathTag($content){
+        return str_replace("<math>", "<math xmlns='http://www.w3.org/1998/Math/MathML'>", $content);
     }
 
     // Traverse the -i option and find all paths with files
@@ -194,6 +199,7 @@ class ConvertToQtiService
         $content = $json['content'];
         $tags = $json['tags'];
         $itemReference = $json['reference'];
+
         foreach ($json['questions'] as $question) :
             $question['content'] = $content;
             $question['itemreference'] = $itemReference;

--- a/src/Services/ConvertToQtiService.php
+++ b/src/Services/ConvertToQtiService.php
@@ -185,7 +185,7 @@ class ConvertToQtiService
     /**
      * Converts Learnosity JSON to QTI
      *
-     * @param  string $json
+     * @param  array $json
      *
      * @return array - the results of the conversion
      *
@@ -207,7 +207,9 @@ class ConvertToQtiService
                 $result = Converter::convertLearnosityToQtiItem($question);
                 $result[0] = str_replace('/vendor/learnosity/itembank/', '', $result[0]);
                 $result[0] = str_replace('xmlns:default="http://www.w3.org/1998/Math/MathML"', '', $result[0]);
-                $result[0] = str_replace('default:', '', $result[0]);
+                //TODO: Change this to only select MathML elements?
+                $result[0] = str_replace('<default:', '<', $result[0]);
+                $result[0] = str_replace('</default:', '</', $result[0]);
                 $finalXml[] = $result;
                 $tagsArray[$question['reference']] = $tags;
             } else {

--- a/src/Services/ConvertToQtiService.php
+++ b/src/Services/ConvertToQtiService.php
@@ -206,7 +206,7 @@ class ConvertToQtiService
             if (in_array($question['data']['type'], LearnosityExportConstant::$supportedQuestionTypes)) {
                 $result = Converter::convertLearnosityToQtiItem($question);
                 $result[0] = str_replace('/vendor/learnosity/itembank/', '', $result[0]);
-                $result[0] = str_replace('xmlns:default="http://www.w3.org/1998/Math/MathML"','',$result[0]);
+                $result[0] = str_replace('xmlns:default="http://www.w3.org/1998/Math/MathML"', '', $result[0]);
                 $result[0] = str_replace('default:', '', $result[0]);
                 $finalXml[] = $result;
                 $tagsArray[$question['reference']] = $tags;

--- a/src/Services/ConvertToQtiService.php
+++ b/src/Services/ConvertToQtiService.php
@@ -206,6 +206,8 @@ class ConvertToQtiService
             if (in_array($question['data']['type'], LearnosityExportConstant::$supportedQuestionTypes)) {
                 $result = Converter::convertLearnosityToQtiItem($question);
                 $result[0] = str_replace('/vendor/learnosity/itembank/', '', $result[0]);
+                $result[0] = str_replace('xmlns:default="http://www.w3.org/1998/Math/MathML"','',$result[0]);
+                $result[0] = str_replace('default:', '', $result[0]);
                 $finalXml[] = $result;
                 $tagsArray[$question['reference']] = $tags;
             } else {


### PR DESCRIPTION
Conversion library is not converting the item's json into xml if item json contain math Tag .

Solution : 
Conversion library should convert the item's json if Math tag is present . 