### PR TITLE
Images linked via <object> elements don't preserve dimensions (WBL-69)

### DIFF
--- a/src/Processors/QtiV2/Marshallers/LearnosityObjectMarshaller.php
+++ b/src/Processors/QtiV2/Marshallers/LearnosityObjectMarshaller.php
@@ -25,6 +25,8 @@ class LearnosityObjectMarshaller extends ObjectMarshaller
                 $this->checkObjectComponents($component, '<img> tag');
                 $element = self::getDOMCradle()->createElement('img');
                 $element->setAttribute('src', $component->getData());
+                $element->setAttribute('width', $component->getWidth());
+                $element->setAttribute('height', $component->getHeight());
                 return $element;
                 break;
             case self::MIME_AUDIO:


### PR DESCRIPTION
Some QTI content has images linked via <object> elements. In this case, even if the width and height attributes are there, the converter doesn't preserve them in the final JSON.

Desired conversion
XML
`<object data="../images/288080/152778.jpg" height="283" type="image/jpeg" width="280"/>`
 

JSON
`<img src=\"https://assets.learnosity.com/organisations/577/152778.jpg\" height="283" width="280"/>`