### PR TITLE
Extra spacing is added after each <hottext> element in tokenhighlight

### DIFF
--- a/src/Processors/QtiV2/In/Interactions/HottextInteractionMapper.php
+++ b/src/Processors/QtiV2/In/Interactions/HottextInteractionMapper.php
@@ -58,8 +58,8 @@ class HottextInteractionMapper extends AbstractInteractionMapper
 
             // Inject token spans where there are inline hottext nodes
             // HACK: because these tokens are inline, make sure there is space between the token and its inline siblings
-            $content = str_replace($hottextString, ' ' . QtiMarshallerUtil::marshall($tokenSpan) . '', $content);
-		}
+            $content = str_replace($hottextString, ' ' . QtiMarshallerUtil::marshall($tokenSpan), $content);
+        }
         return $content;
     }
 

--- a/src/Processors/QtiV2/In/Interactions/HottextInteractionMapper.php
+++ b/src/Processors/QtiV2/In/Interactions/HottextInteractionMapper.php
@@ -58,8 +58,8 @@ class HottextInteractionMapper extends AbstractInteractionMapper
 
             // Inject token spans where there are inline hottext nodes
             // HACK: because these tokens are inline, make sure there is space between the token and its inline siblings
-            $content = str_replace($hottextString, ' '.QtiMarshallerUtil::marshall($tokenSpan).'', $content);
-        }
+            $content = str_replace($hottextString, ' ' . QtiMarshallerUtil::marshall($tokenSpan) . '', $content);
+		}
         return $content;
     }
 

--- a/src/Processors/QtiV2/In/Interactions/HottextInteractionMapper.php
+++ b/src/Processors/QtiV2/In/Interactions/HottextInteractionMapper.php
@@ -58,7 +58,7 @@ class HottextInteractionMapper extends AbstractInteractionMapper
 
             // Inject token spans where there are inline hottext nodes
             // HACK: because these tokens are inline, make sure there is space between the token and its inline siblings
-            $content = str_replace($hottextString, ' '.QtiMarshallerUtil::marshall($tokenSpan).' ', $content);
+            $content = str_replace($hottextString, ' '.QtiMarshallerUtil::marshall($tokenSpan).'', $content);
         }
         return $content;
     }


### PR DESCRIPTION
Extra spacing is added after each <hottext> element in tokenhighlight. 
Fixed.