### PR TITLE
Add logic to convert certain items to imageclozeassociation (WBL-68)

### DIFF
--- a/src/Processors/Learnosity/In/ValidationBuilder/ValidationBuilder.php
+++ b/src/Processors/Learnosity/In/ValidationBuilder/ValidationBuilder.php
@@ -53,7 +53,7 @@ class ValidationBuilder
                 $validResponse = $validResponseRef->newInstance();
                 $validResponse->set_score($response->getScore());
                 if($questionType == 'imageclozeassociationV2') {
-                   $convertArray = array_map(array(__CLASS__, 'convertArrayIntoArrayOfArray'), $response->getValue());
+                   $convertArray = self::convertArrayIntoArrayOfArray($response->getValue());
                    $validResponse->set_value($convertArray);
                 } else {
                     $validResponse->set_value($response->getValue());
@@ -84,11 +84,13 @@ class ValidationBuilder
     /**
      * Function to convert array value into array
      *
-     * @param type $value value of array
+     * @param type $responseArray response array
      * @return type converted array
      */
-    private function convertArrayIntoArrayOfArray($value){
-        $convertArray[] = $value;
+    private static function convertArrayIntoArrayOfArray($responseArray){
+        foreach($responseArray as $value) {
+            $convertArray[] = array($value);
+        }
         return $convertArray;
     }
 


### PR DESCRIPTION
Internally, Learnosity treats Fill in the Blanks (drag&drop) as 2 possible question types:

clozeassociation

imageclozeassociationV2

One with a background image (imageclozeassociationV2) and one without (clozeassociation). This is purely historical, but something the QTI library has no knowledge of, and it defaults to clozeassociation.

We’d like a change to the conversion library, so that if an image is found in the <itemBody> element, we convert QTI to imageclozeassociationV2. 