### PR TITLE
Incorrectly managed selfclosing tags like <img> passed like that: <img height=... //> (double //, not single) results in PHP Notice: Undefined variable: xmlString (WBL-72)

### DIFF
--- a/src/Services/LearnosityToQtiPreProcessingService.php
+++ b/src/Services/LearnosityToQtiPreProcessingService.php
@@ -40,7 +40,9 @@ class LearnosityToQtiPreProcessingService
         /** @var array $selfClosingTags ie. `img, br, input, meta, link, hr, base, embed, spacer` */
         $selfClosingTags = implode(array_keys($html->getSelfClosingTags()), ', ');
         foreach ($html->find($selfClosingTags) as &$node) {
-            $node->outertext = rtrim($node->outertext, '>') . '/>';
+            if (!strpos($node->outertext, '/>')) {
+                $node->outertext = rtrim($node->outertext, '>') . '/>';
+            }
         }
 
         // Replace these audioplayer and videoplayer feature with <object> nodes


### PR DESCRIPTION
Issue
Incorrectly managed selfclosing tags like [img] passed like that: [img height=... //] (double //, not single) results in PHP Notice: Undefined variable: xmlString in C:\Users\learn\Documents\learnosity-qti\src\Converter.php on line 275