### PR TITLE
Set specific item and widget references for passages (WBL-77)

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -185,6 +185,7 @@ class Converter
         $itemReferece = UuidUtil::generate();
         $itemData['reference'] = $itemReferece;
         $itemData['status'] = 'published';
+        $itemData['questions'] = array();
         $itemData['definition']['template'] = 'dynamic';
         $features = $passageMapper->parseHtml($htmlString);
         $featuresData = [];
@@ -194,11 +195,11 @@ class Converter
                 unset($convertedFeature['item_reference']);
                 $featuresData[] = $convertedFeature;
                 $itemData['definition']['widgets'][]['reference'] = $convertedFeature['reference'];
+                $itemData['features'][]['reference'] = $convertedFeature['reference'];
             }
         }
         // Flush out all the error messages stored in this static class, also ensure they are unique
         $messages = array_values(array_unique(LogService::flush()));
-
         return [
             'item' => $itemData,
             'features' => $featuresData,

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -182,7 +182,6 @@ class Converter
     {
         $questionWriter = AppContainer::getApplicationContainer()->get('learnosity_question_writer');
         $passageMapper = new SharedPassageMapper();
-        $itemData['reference'] = UuidUtil::generate();
         $itemData['status'] = 'published';
         $itemData['questions'] = array();
         $itemData['definition']['template'] = 'dynamic';
@@ -199,6 +198,7 @@ class Converter
                 $itemData['features'][]['reference'] = $featureDataHash;
             }
         }
+        $itemData['reference'] = $featureDataHash;
         // Flush out all the error messages stored in this static class, also ensure they are unique
         $messages = array_values(array_unique(LogService::flush()));
         return [

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -182,7 +182,12 @@ class Converter
     {
         $questionWriter = AppContainer::getApplicationContainer()->get('learnosity_question_writer');
         $passageMapper = new SharedPassageMapper();
-        $itemReferece = UuidUtil::generate();
+        $bodyContent = preg_match('/<body>(.*?)<\/body>/s', $htmlString, $match);
+        if (is_array($match) && isset($match[1])) {
+            $itemReferece = md5($match[1]);
+        } else {
+            $itemReferece = UuidUtil::generate();
+        }
         $itemData['reference'] = $itemReferece;
         $itemData['status'] = 'published';
         $itemData['questions'] = array();
@@ -192,10 +197,11 @@ class Converter
         if (isset($features['features']) && is_array($features['features'])) {
             foreach ($features['features'] as $feature) {
                 $convertedFeature = $questionWriter->convert($feature);
+                $convertedFeature['reference'] = $itemReferece;
                 unset($convertedFeature['item_reference']);
                 $featuresData[] = $convertedFeature;
-                $itemData['definition']['widgets'][]['reference'] = $convertedFeature['reference'];
-                $itemData['features'][]['reference'] = $convertedFeature['reference'];
+                $itemData['definition']['widgets'][]['reference'] = $itemReferece;
+                $itemData['features'][]['reference'] = $itemReferece;
             }
         }
         // Flush out all the error messages stored in this static class, also ensure they are unique

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -182,13 +182,6 @@ class Converter
     {
         $questionWriter = AppContainer::getApplicationContainer()->get('learnosity_question_writer');
         $passageMapper = new SharedPassageMapper();
-        $bodyContent = preg_match('/<body>(.*?)<\/body>/s', $htmlString, $match);
-        if (is_array($match) && isset($match[1])) {
-            $itemReferece = md5($match[1]);
-        } else {
-            $itemReferece = UuidUtil::generate();
-        }
-        $itemData['reference'] = $itemReferece;
         $itemData['status'] = 'published';
         $itemData['questions'] = array();
         $itemData['definition']['template'] = 'dynamic';
@@ -196,14 +189,16 @@ class Converter
         $featuresData = [];
         if (isset($features['features']) && is_array($features['features'])) {
             foreach ($features['features'] as $feature) {
+                $featureDataHash = sha1(json_encode($feature->to_array()['data']));
                 $convertedFeature = $questionWriter->convert($feature);
-                $convertedFeature['reference'] = $itemReferece;
+                $convertedFeature['reference'] = $featureDataHash;
                 unset($convertedFeature['item_reference']);
                 $featuresData[] = $convertedFeature;
-                $itemData['definition']['widgets'][]['reference'] = $itemReferece;
-                $itemData['features'][]['reference'] = $itemReferece;
+                $itemData['definition']['widgets'][]['reference'] = $featureDataHash;
+                $itemData['features'][]['reference'] = $featureDataHash;
             }
         }
+        $itemData['reference'] = $featureDataHash;
         // Flush out all the error messages stored in this static class, also ensure they are unique
         $messages = array_values(array_unique(LogService::flush()));
         return [

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -182,6 +182,7 @@ class Converter
     {
         $questionWriter = AppContainer::getApplicationContainer()->get('learnosity_question_writer');
         $passageMapper = new SharedPassageMapper();
+        $itemData['reference'] = UuidUtil::generate();
         $itemData['status'] = 'published';
         $itemData['questions'] = array();
         $itemData['definition']['template'] = 'dynamic';
@@ -198,7 +199,6 @@ class Converter
                 $itemData['features'][]['reference'] = $featureDataHash;
             }
         }
-        $itemData['reference'] = $featureDataHash;
         // Flush out all the error messages stored in this static class, also ensure they are unique
         $messages = array_values(array_unique(LogService::flush()));
         return [


### PR DESCRIPTION
This is for converting QTI to Learnosity JSON.

We have a problem where duplicate passages are being created because we create new UUID for the widget reference every time we convert QTI to JSON.

Can we look at hashing the body of the passage and use that as both the item and widget reference? This would mean that in a single QTI content package, we would re-use the same sharedpassage if it was used in multiple items. But also when separate QTI content packages were converted, we’d keep the same sharedpassage reference, and therefore actually “share” the passage, rather than creating a brand new one.

