### PR TITLE
"scorer" rubrics to be created as separate items (WBL-78)

### DIFF
--- a/src/Processors/QtiV2/In/ItemBuilders/AbstractItemBuilder.php
+++ b/src/Processors/QtiV2/In/ItemBuilders/AbstractItemBuilder.php
@@ -2,16 +2,16 @@
 
 namespace LearnosityQti\Processors\QtiV2\In\ItemBuilders;
 
-use \LearnosityQti\Entities\Item\item;
-use \LearnosityQti\Processors\QtiV2\In\ResponseProcessingTemplate;
-use \LearnosityQti\Processors\QtiV2\In\Constants;
-use \qtism\data\content\ItemBody;
-use \qtism\data\QtiComponentCollection;
-use \qtism\data\AssessmentItem;
-use qtism\data\content\RubricBlock;
+use LearnosityQti\Entities\Item\item;
+use LearnosityQti\Entities\Question;
+use LearnosityQti\Processors\QtiV2\In\ResponseProcessingTemplate;
 use LearnosityQti\Processors\QtiV2\In\RubricBlockMapper;
 use LearnosityQti\Services\LogService;
-use LearnosityQti\Entities\Question;
+use qtism\data\AssessmentItem;
+use qtism\data\content\ItemBody;
+use qtism\data\content\RubricBlock;
+use qtism\data\QtiComponentCollection;
+use qtism\data\View;
 
 abstract class AbstractItemBuilder
 {
@@ -285,7 +285,11 @@ abstract class AbstractItemBuilder
             });
             $widgetsToInsert = array_merge($widgetsToInsert, $features);
             foreach ($features as $featureReference => $feature) {
-                $this->rubricData['featureReferences'][] = [ 'reference' => $feature->get_reference() ];
+                $view = 0;
+                if ($result['views']->contains(View::SCORER)) {
+                    $view = View::SCORER;
+                }
+                $this->rubricData['featureReferences'][] = ['reference' => $feature->get_reference(), 'view' => $view];
             }
         }
 

--- a/src/Processors/QtiV2/In/RubricBlockMapper.php
+++ b/src/Processors/QtiV2/In/RubricBlockMapper.php
@@ -104,7 +104,6 @@ class RubricBlockMapper
                     ];
                 }
                 break;
-
             case ($rubricBlock->getClass() === 'ScoringGuidance'):
                 /* falls through */
             case (!$views->contains(View::CANDIDATE)):
@@ -114,6 +113,7 @@ class RubricBlockMapper
         }
 
         if (!empty($result)) {
+            $result['views'] = $rubricBlock->getViews();
             return $result;
         } else {
             $rubricUse = $rubricBlock->getUse();
@@ -277,7 +277,6 @@ class RubricBlockMapper
         // rubric content, as opposed to regular item or passage content
         $result['type']  = 'ScoringGuidance';
         $result['label'] = $rubricBlock->getLabel();
-
         return $result;
     }
 


### PR DESCRIPTION
Right now, any <rubricBlock> element in an <assessmentItem> is being converted to a passage. We need to distinguish between different use-cases.
Linking the scoring rubric to the question
We need to link the 2nd passage-only item (the scoring rubric) to the longtextV2 question type in the <assessmentItem> after conversion. To do this we’d use the rubric_reference property on the essay question type, like the following:

{
    "stimulus": "<p>extended text QTI content here</p>",
    "type": "longtextV2",
    "metadata": {
        "rubric_reference": "ITEM-LOGIC--622869_rubric"
    }
}