### PR TITLE
Ability to convert a single QTI file to Learnosity JSON (WBL-81)

### DIFF
--- a/src/Commands/ConvertToLearnosityCommand.php
+++ b/src/Commands/ConvertToLearnosityCommand.php
@@ -60,6 +60,14 @@ class ConvertToLearnosityCommand extends Command
                 . 'the manifest',
                 'N'
             )
+             ->addOption(
+                'single-item',
+                '',
+                InputOption::VALUE_OPTIONAL,
+                'If you pass the value as "Y", the conversion library will convert only single '
+                 . 'xml file',
+                'N'
+            )
         ;
     }
 
@@ -71,6 +79,7 @@ class ConvertToLearnosityCommand extends Command
         $organisationId = $input->getOption('organisation_id');
         $itemReferenceSource = $input->getOption('item-reference-source');
         $isConvertPassageContent = strtoupper($input->getOption('passage-only-items'));
+        $isSingleItemConvert = strtoupper($input->getOption('single-item'));
 
         // Validate the required options
         if (empty($inputPath) || empty($outputPath)) {
@@ -105,6 +114,14 @@ class ConvertToLearnosityCommand extends Command
             );
         }
 
+        $requiredValuesForSingleItemConversion = ['Yes or Y', 'No or N'];
+        if($isSingleItemConvert != 'Y' && $isSingleItemConvert != 'YES' && $isSingleItemConvert != 'N' && $isSingleItemConvert != 'NO') {
+            array_push(
+                $validationErrors,
+                "The <info>single-item</info> must be one of the following values: " . join(', ', $requiredValuesForSingleItemConversion)
+            );
+        }
+
         $validItemReferenceSources = ['item', 'metadata', 'filename', 'resource'];
         if (isset($itemReferenceSource) && !in_array($itemReferenceSource, $validItemReferenceSources)) {
             array_push(
@@ -128,7 +145,7 @@ class ConvertToLearnosityCommand extends Command
             ]);
         } else {
 
-            $Convert = ConvertToLearnosityService::initClass($inputPath, $outputPath, $output, $organisationId, $isConvertPassageContent);
+            $Convert = ConvertToLearnosityService::initClass($inputPath, $outputPath, $output, $organisationId, $isConvertPassageContent, $isSingleItemConvert);
 
             $Convert->useMetadataIdentifier(true);
             $Convert->useResourceIdentifier(false);

--- a/src/Commands/ConvertToLearnosityCommand.php
+++ b/src/Commands/ConvertToLearnosityCommand.php
@@ -87,7 +87,7 @@ class ConvertToLearnosityCommand extends Command
         }
 
         // Make sure we can read the input folder, and write to the output folder
-        if (!empty($inputPath) && !is_dir($inputPath)) {
+        if (!empty($inputPath) && !is_dir($inputPath) && $isSingleItemConvert != 'Y' && $isSingleItemConvert != 'YES') {
             $output->writeln([
                 "Input path isn't a directory (<info>$inputPath</info>)"
             ]);


### PR DESCRIPTION
Can we add support for a new command line argument, --single-item yes, and if passed we assume the --input argument points to a single XML file only. Not a folder that contains many XML files and an imsmanifest.xml.