### PR TITLE
Extra divs being added to JSON text fields (WBL-80)

### DIFF
--- a/src/Processors/QtiV2/In/Interactions/OrderInteractionMapper.php
+++ b/src/Processors/QtiV2/In/Interactions/OrderInteractionMapper.php
@@ -26,9 +26,7 @@ class OrderInteractionMapper extends AbstractInteractionMapper
         /** @var SimpleChoice $simpleChoice */
         foreach ($interaction->getSimpleChoices() as $simpleChoice) {
             $this->orderMapping[$simpleChoice->getIdentifier()] = count($this->orderMapping);
-            $choiceContent = QtiMarshallerUtil::marshallCollection($simpleChoice->getContent());
-            $listContent = trim(str_replace("\n", "", $choiceContent));
-            $list[] = $listContent;
+            $list[] = QtiMarshallerUtil::marshallCollection($simpleChoice->getContent());
         }
 
         $question = new orderlist('orderlist', $list);

--- a/src/Processors/QtiV2/In/Interactions/OrderInteractionMapper.php
+++ b/src/Processors/QtiV2/In/Interactions/OrderInteractionMapper.php
@@ -26,7 +26,7 @@ class OrderInteractionMapper extends AbstractInteractionMapper
         /** @var SimpleChoice $simpleChoice */
         foreach ($interaction->getSimpleChoices() as $simpleChoice) {
             $this->orderMapping[$simpleChoice->getIdentifier()] = count($this->orderMapping);
-            $list[] = QtiMarshallerUtil::marshallCollection($simpleChoice->getContent());
+            $list[] = preg_replace('/\s+/', '', QtiMarshallerUtil::marshallCollection($simpleChoice->getContent()));
         }
 
         $question = new orderlist('orderlist', $list);

--- a/src/Processors/QtiV2/In/Interactions/OrderInteractionMapper.php
+++ b/src/Processors/QtiV2/In/Interactions/OrderInteractionMapper.php
@@ -26,7 +26,9 @@ class OrderInteractionMapper extends AbstractInteractionMapper
         /** @var SimpleChoice $simpleChoice */
         foreach ($interaction->getSimpleChoices() as $simpleChoice) {
             $this->orderMapping[$simpleChoice->getIdentifier()] = count($this->orderMapping);
-            $list[] = preg_replace('/\s+/', '', QtiMarshallerUtil::marshallCollection($simpleChoice->getContent()));
+            $choiceContent = QtiMarshallerUtil::marshallCollection($simpleChoice->getContent());
+            $listContent = trim(str_replace("\n", "", $choiceContent));
+            $list[] = $listContent;
         }
 
         $question = new orderlist('orderlist', $list);

--- a/src/Processors/QtiV2/In/ItemBuilders/RegularItemBuilder.php
+++ b/src/Processors/QtiV2/In/ItemBuilders/RegularItemBuilder.php
@@ -55,6 +55,7 @@ class RegularItemBuilder extends AbstractItemBuilder
                 $component->getQtiClassName(),
                 [$component, $responseDeclaration, $responseProcessingTemplate, $outcomeDeclaration, $this->organisationId]
             );
+
             $question = $mapper->getQuestionType();
 
             $this->questions[$questionReference] = new Question($question->get_type(), $questionReference, $question);
@@ -102,9 +103,12 @@ class RegularItemBuilder extends AbstractItemBuilder
             }
 
             //replace the previous interaction content from this question stimulus
-            $stimulus = '<div>';
-            $stimulus .= str_replace($previousContent, '', $contentList);
-            $stimulus .= '</div>';
+            $stimulus = '';
+            if($contentList != '') {
+                $stimulus = '<div>';
+                $stimulus .= str_replace($previousContent, '', $contentList);
+                $stimulus .= '</div>';
+            }
 
             //store the previous interaction stimulus
             $previousContent = $contentList;

--- a/src/Utils/QtiMarshallerUtil.php
+++ b/src/Utils/QtiMarshallerUtil.php
@@ -67,7 +67,13 @@ class QtiMarshallerUtil
                 $results[] = static::marshall($component);
             }
         }
-        return implode('', $results);
+        // Clean extra whitespace characters from the returned string
+        $cleanedResults = trim(
+            str_replace(
+                ["\r\n", "\n", "\r", "\t"], "", implode('', $results)
+            )
+        );
+        return $cleanedResults;
     }
 
     public static function marshall(QtiComponent $component)


### PR DESCRIPTION
After conversion 
Note the <div></div> fields at the start of stimulus that need to be removed.

Note the new-line character (and spacing) in list that should be trimmed.

While the empty <div>'s appear at the front of stimulus, the new-line character appears in most JSON text properties. Is there a way to replace them with nothing across the entire JSON object?

https://learnosity.atlassian.net/browse/WBL-80

