### PR TITLE
Distractor rationale being converted incorrectly (WBL-83)

### DIFF
--- a/src/Processors/QtiV2/In/DistractorRationaleResponseMapper.php
+++ b/src/Processors/QtiV2/In/DistractorRationaleResponseMapper.php
@@ -50,11 +50,8 @@ class DistractorRationaleResponseMapper
             $i = 0 ;
             foreach ($innerContent->childNodes as $child) {
                 $elementId = $child->getAttribute('id');
-                while($child->firstChild instanceof DOMElement){
-                    $child = $child->firstChild;
-                }
                 $distractorRationale[$i]['id'] = $elementId;
-                $distractorRationale[$i]['content'] = $child->ownerDocument->saveXML($child->parentNode);
+                $distractorRationale[$i]['content'] = $child->ownerDocument->saveXML($child);
                 $i++;
             }
             $results['distractor_rationale_per_response'] = $distractorRationale;

--- a/src/Processors/QtiV2/In/ItemBuilders/AbstractItemBuilder.php
+++ b/src/Processors/QtiV2/In/ItemBuilders/AbstractItemBuilder.php
@@ -148,7 +148,9 @@ abstract class AbstractItemBuilder
                 case 'distractor_rationale_response_level':
                     $metadata->set_distractor_rationale_response_level($value);
                     break;
-
+                case 'distractor_rationale_per_response':
+                    $metadata->distractor_rationale_per_response = $metadataValues['distractor_rationale_per_response'];
+                    break;
                 case 'rubric_reference':
                     $metadata->set_rubric_reference($value);
             }

--- a/src/Processors/QtiV2/In/ItemMapper.php
+++ b/src/Processors/QtiV2/In/ItemMapper.php
@@ -2,19 +2,20 @@
 
 namespace LearnosityQti\Processors\QtiV2\In;
 
-use \LearnosityQti\AppContainer;
-use \LearnosityQti\Exceptions\MappingException;
-use \LearnosityQti\Processors\QtiV2\In\Processings\AbstractXmlProcessing;
-use \LearnosityQti\Processors\QtiV2\In\Processings\ProcessingInterface;
-use \LearnosityQti\Processors\QtiV2\In\ResponseProcessingTemplate;
-use \LearnosityQti\Services\LogService;
-use \qtism\data\AssessmentItem;
-use \qtism\data\content\ItemBody;
-use \qtism\data\processing\ResponseProcessing;
-use \qtism\data\storage\xml\XmlDocument;
-use qtism\data\content\RubricBlock;
+use LearnosityQti\AppContainer;
+use LearnosityQti\Entities\Question;
+use LearnosityQti\Exceptions\MappingException;
+use LearnosityQti\Processors\QtiV2\In\Processings\AbstractXmlProcessing;
+use LearnosityQti\Processors\QtiV2\In\Processings\ProcessingInterface;
+use LearnosityQti\Processors\QtiV2\In\ResponseProcessingTemplate;
+use LearnosityQti\Services\LogService;
+use qtism\data\AssessmentItem;
 use qtism\data\content\BlockCollection;
+use qtism\data\content\ItemBody;
+use qtism\data\content\RubricBlock;
+use qtism\data\processing\ResponseProcessing;
 use qtism\data\QtiComponentCollection;
+use qtism\data\storage\xml\XmlDocument;
 
 class ItemMapper
 {
@@ -170,15 +171,40 @@ class ItemMapper
         if ($assessmentItem->getTitle()) {
             $item->set_description($assessmentItem->getTitle());
         }
+
         // Handle additional (related) items being passed back
         $rubric = $itemBuilder->getRubricItem();
 
-        $questions = $itemBuilder->getQuestions();
+        $questions = $this->removeDistractorRationalePerResponse($itemBuilder->getQuestions());
         
         $features = $itemBuilder->getFeatures();
 
         // Support additional (related) items being passed back
         return [$item, $questions, $features, $rubric];
+    }
+
+    private function removeDistractorRationalePerResponse($questions)
+    {
+        foreach ($questions as $questionId => $question) {
+            $choicesIdentifires = array();
+            if (method_exists($question->get_data(), 'get_options') && is_array($question->get_data()->get_options())) {
+                $choiceArray = $question->get_data()->get_options();
+                $choicesIdentifires = array_column($choiceArray, 'value');
+            }
+            if (method_exists($question->get_data(), 'get_metadata') && isset($question->get_data()->get_metadata()->distractor_rationale_per_response) && is_array($question->get_data()->get_metadata()->distractor_rationale_per_response)) {
+                $distractorRationalePerResponses = $question->get_data()->get_metadata()->distractor_rationale_per_response;
+                $newDist = array();
+                foreach ($distractorRationalePerResponses as $distractorRationalePerResponse) {
+                    foreach ($choicesIdentifires as $choiceIdentifire) {
+                        if (stristr($distractorRationalePerResponse['id'], $choiceIdentifire) !== FALSE) {
+                            $newDist[] = $distractorRationalePerResponse['content'];
+                        }
+                    }
+                }
+                $questions[$questionId]->get_data()->get_metadata()->distractor_rationale_per_response = $newDist;
+            }
+        }
+        return $questions;
     }
 
     /**
@@ -363,7 +389,7 @@ class ItemMapper
      *
      * @param  \qtism\data\processing\ResponseProcessing $responseProcessing
      *
-     * @return \LearnosityQti\Processors\QtiV2\In\ResponseProcessingTemplate
+     * @return ResponseProcessingTemplate
      */
     private function getResponseProcessingTemplate(ResponseProcessing $responseProcessing = null)
     {

--- a/src/Processors/QtiV2/In/RubricBlockMapper.php
+++ b/src/Processors/QtiV2/In/RubricBlockMapper.php
@@ -75,8 +75,6 @@ class RubricBlockMapper
                 }
                 break;
 
-            case ($rubricBlock->getClass() === 'DistractorRationale'):
-                /* falls through */
             case ($rubricBlock->getUse() === 'rationale'):
                 if ($views->contains(View::CANDIDATE)) {
                     $mapper = new DistractorRationaleResponseMapper();
@@ -89,7 +87,7 @@ class RubricBlockMapper
                 }
                 break;
 
-            case ($rubricBlock->getUse() !== 'rationale');
+            case ($rubricBlock->getClass() === 'DistractorRationale');
                 if ($views->contains(View::AUTHOR)) {
                     $result = [
                         'question_metadata' => [

--- a/src/Processors/QtiV2/In/RubricBlockMapper.php
+++ b/src/Processors/QtiV2/In/RubricBlockMapper.php
@@ -89,6 +89,21 @@ class RubricBlockMapper
                 }
                 break;
 
+            case ($rubricBlock->getUse() !== 'rationale');
+                if ($views->contains(View::AUTHOR)) {
+                    $result = [
+                        'question_metadata' => [
+                            'distractor_rationale_author' => [
+                                [
+                                    'label' => $rubricBlock->getLabel(),
+                                    'content' => QtiMarshallerUtil::marshallCollection($rubricBlock->getContent()),
+                                ]
+                            ],
+                        ],
+                    ];
+                }
+                break;
+
             case ($rubricBlock->getUse() === 'stimulus'):
                 if ($views->contains(View::CANDIDATE)) {
                     $contents = QtiMarshallerUtil::marshallCollection($rubricBlock->getContent());

--- a/src/Processors/QtiV2/In/RubricBlockMapper.php
+++ b/src/Processors/QtiV2/In/RubricBlockMapper.php
@@ -82,17 +82,10 @@ class RubricBlockMapper
                     $mapper = new DistractorRationaleResponseMapper();
                     $distractorRationalResponseLevelArray = $mapper->parseWithDistractorRationaleResponseComponent($rubricBlock);
                     $result ['question_metadata'] = $distractorRationalResponseLevelArray;
-                } else if ($views->contains(View::AUTHOR)) {
-                    $result = [
-                        'question_metadata' => [
-                            'distractor_rationale_author' => [
-                                [
-                                    'label' => $rubricBlock->getLabel(),
-                                    'content' => QtiMarshallerUtil::marshallCollection($rubricBlock->getContent()),
-                                ]
-                            ],
-                        ],
-                    ];
+                } else if ($views->contains(View::AUTHOR) || $views->contains(View::SCORER) || $views->contains(View::TUTOR)) {
+                    $mapper = new DistractorRationaleResponseMapper();
+                    $distractorRationalResponseLevelArray = $mapper->parseWithDistractorRationalePerResponseComponent($rubricBlock);
+                    $result ['question_metadata'] = $distractorRationalResponseLevelArray;
                 }
                 break;
 


### PR DESCRIPTION
his is converting QTI to Learnosity JSON.

distractors are being written into `metadata.distractor_rationale_author` which is an invalid JSON property. They should be mapped to `metadata.distractor_rationale_per_response`.

Rules
When “use” is “rationale”, and “view” contains either “author”, “scorer” or “tutor”, then write to metadata.distractor_rationale_per_response as an array of strings.