### PR TITLE
Conversion library is failing to convert item's json into QTI, due to recent change in itembank json

### DIFF
--- a/src/Services/ConvertToQtiService.php
+++ b/src/Services/ConvertToQtiService.php
@@ -248,7 +248,11 @@ class ConvertToQtiService
                 $this->itemReferences = $activityJson->data->items;
                 if (!empty($this->itemReferences)) {
                     foreach ($this->itemReferences as $itemref) {
-                        $itemref = md5($itemref);
+                        if(isset($itemref) && is_object($itemref) && isset($itemref->id)) {
+                            $itemref = md5($itemref->id);
+                        } else {
+                            $itemref = md5($itemref);
+                        }
                         $folders[] = $this->inputPath . '/items/' . $itemref . '.json';
                     }
                 } else {


### PR DESCRIPTION
This is for learnosity to QTI conversion .

Due to recent change in itembank json Conversion library is failing to convert item's json into QTI .

Please find below the change in itembank json and make the necessary changes in conversion library to support both the format new and old .

Key changes should be
a) the format of items list in the manifest (supporting arrays of objects with ids and references, as well as arrays of plain string references)
b) additional metadata in the item JSON files for asset path mapping and source
c) item JSON filenames are hashed differently 