### PR TITLE
Fix a few fatal errors and notices

### DIFF
--- a/src/Commands/DefaultCommand.php
+++ b/src/Commands/DefaultCommand.php
@@ -29,5 +29,7 @@ class DefaultCommand extends Command
             '<comment>Commands:</comment>',
             "  <info>mo list</info>\tRun this to see the available commands",
         ]);
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -33,5 +33,7 @@ class ListCommand extends Command
             "  <info>list</info>\t\t\t\tLists all commands available",
             '',
         ]);
+
+        return Command::SUCCESS;
     }
 }

--- a/src/Services/ConvertToLearnosityService.php
+++ b/src/Services/ConvertToLearnosityService.php
@@ -31,10 +31,6 @@ class ConvertToLearnosityService
     protected $inputPath;
     protected $outputPath;
     protected $output;
-    protected $finalPath;
-    protected $logPath;
-    protected $rawPath;
-    protected $useItemIdentifier;
     protected $organisationId;
     protected $isConvertPassageContent;
     protected $isSingleItemConvert;

--- a/src/Services/ItemLayoutService.php
+++ b/src/Services/ItemLayoutService.php
@@ -18,8 +18,6 @@ class ItemLayoutService
     protected $recreateOutputDir                    = false;
 
     private $output;
-    private $doItemMigration;
-    private $recreateOutputDir;
 
     public function execute($inputPath, $outputPath, OutputInterface $output)
     {


### PR DESCRIPTION
When trying to use the tool a few notices were thrown by `mo` and `mo list`. Also, the conversion from QTI to Learnosity JSON was throwing fatal errors due to a few properties being declared a second time in a few services.